### PR TITLE
Update syntax to remove call to set-output

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -15,13 +15,13 @@ jobs:
 
       - name: Read .nvmrc
         id: nvm
-        run: |
-          echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: |          
+          echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_ENV
 
-      - name: Setup Node.js - ${{ steps.nvm.outputs.NVMRC }}
+      - name: Setup Node.js - ${{ steps.NVMRC }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version: ${{ steps.NVMRC }}
           cache: 'npm'
 
       - name: Confirm Node and NPM versions

--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -18,10 +18,10 @@ jobs:
         run: |          
           echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_ENV
 
-      - name: Setup Node.js - ${{ steps.NVMRC }}
+      - name: Setup Node.js - ${{ env.NVMRC }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.NVMRC }}
+          node-version: ${{ env.NVMRC }}
           cache: 'npm'
 
       - name: Confirm Node and NPM versions


### PR DESCRIPTION
## Description
- Use GH env variable instead of ::set-ouput as per docs

### Docs
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
