### PR TITLE
add ms teams notification for manage nonprod cluster workflow; amend …

### DIFF
--- a/.github/workflows/manage-nonprod-rds-clusters.yaml
+++ b/.github/workflows/manage-nonprod-rds-clusters.yaml
@@ -138,3 +138,12 @@ jobs:
             --db-cluster-identifier $cluster_name | jq -r '.DBCluster.DBClusterIdentifier')
             echo "$action_message" >> $GITHUB_STEP_SUMMARY
           done
+
+      - name: 🔔 Send MS Teams Notification
+        if: always()
+        uses: skitionek/notify-microsoft-teams@v1.0.8
+        with:
+          webhook_url: ${{ env.DES_GLOBALS_ENV_MSTEAMS_WEBHOOK_RDS_MANAGEMENT}}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}
+          overwrite: "{title: `Action: ${{ inputs.action || steps.determine-action.outputs.action }} NonProd Clusters | BY: ${{github.actor}}`}"

--- a/.github/workflows/release-manifest.yaml
+++ b/.github/workflows/release-manifest.yaml
@@ -131,12 +131,23 @@ jobs:
           echo "## Release Manifest:" >> $GITHUB_STEP_SUMMARY
           echo "✅ Uploaded ${{ env.FILE_NAME }} to S3" >> $GITHUB_STEP_SUMMARY
 
+  send-teams-notification:
+    if: always()
+    needs: [pre_creation_checks, build_artefact_for_release, create_release_manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📝 Generate MS Teams Notify JSON
+        id: ms-teams-json
+        uses: dvsa/des-workflow-actions/.github/actions/generate-ms-teams-json@main
+        with:
+          needs-context: ${{ toJSON(needs) }}
+
       - name: 🔔 Send MS Teams Notification
         if: always()
         uses: skitionek/notify-microsoft-teams@v1.0.4
         with:
           webhook_url: ${{ env.DES_GLOBALS_ENV_MSTEAMS_WEBHOOK_RELEASE_MANIFEST}}
-          job: ${{ toJson(job) }}
+          job: ${{ steps.ms-teams-json.outputs.job-context }}
           needs: ${{ toJson(needs) }}
-          steps: ${{ toJson(steps) }}
-          overwrite: "{title: `${{github.repository}} | ${{github.workflow}} | BY: ${{github.actor}}`}"
+          steps: ${{ steps.ms-teams-json.outputs.steps-context }}
+          overwrite: "{title: `${{github.repository}} | ${{ github.ref_name }} | BY: ${{github.actor}}`}"


### PR DESCRIPTION
…release manifest teams notification

## Description

add ms teams notification for manage nonprod cluster workflow and amend the release manifest workflow to combine all jobs into teams notification

Related issue: [MES-9505](https://dvsa.atlassian.net/browse/MES-9505)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
