### PR TITLE
add pre-runner-script input to install libicu for the AL2023 AMI to e…

### DIFF
--- a/.github/workflows/manage-gha-tf-runner.yaml
+++ b/.github/workflows/manage-gha-tf-runner.yaml
@@ -80,6 +80,8 @@ jobs:
               {"Key": "RunID", "Value": "${{ github.run_id }}"},
               {"Key": "Type", "Value": "GHA Runner"}
             ]
+          pre-runner-script: | 
+            sudo yum install libicu -y
 
       - name: ⏹️ Stop EC2 Runner
         if: inputs.action == 'stop'


### PR DESCRIPTION
…nable GHA runner setup

## Description

add pre-runner-script input to install libicu for the AL2023 AMI to enable GHA runner setup

Related issue: [MES-9323](https://dvsa.atlassian.net/browse/MES-9323)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
