### PR TITLE
MES-9323 - bump aws-secretsmanager-get-secrets version

### DIFF
--- a/.github/workflows/full-dms-deploy.yaml
+++ b/.github/workflows/full-dms-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
           role-session-name: Terraform-GHA
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true
@@ -55,7 +55,7 @@ jobs:
           role-session-name: Terraform-${{ inputs.aws-account }}-GHA
 
       - name: 🤫 Get ${{ inputs.aws-account }} Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: RDS_CREDENTIALS, des-${{ inputs.tf-environment }}-rds-credentials
           parse-json-secrets: true

--- a/.github/workflows/manage-gha-tf-runner.yaml
+++ b/.github/workflows/manage-gha-tf-runner.yaml
@@ -48,7 +48,7 @@ jobs:
           role-session-name: Terraform-GHA
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-aws/env
           parse-json-secrets: true

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -65,7 +65,7 @@ jobs:
           role-session-name: Terraform-GHA
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -157,7 +157,7 @@ jobs:
           role-session-name: Terraform-GHA
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: RDS_CREDENTIALS, des-${{ inputs.tf-environment }}-rds-credentials
           parse-json-secrets: true


### PR DESCRIPTION
## Description

bump aws-secretsmanager-get-secrets version

Related issue: [MES-9323](https://dvsa.atlassian.net/browse/MES-9323)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
