### PR TITLE
MES-9886: bump aws-secretsmanager-get-secrets action version

### DIFF
--- a/.github/workflows/build-mobile-app-config.yaml
+++ b/.github/workflows/build-mobile-app-config.yaml
@@ -28,7 +28,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true

--- a/.github/workflows/build-squidnat-artefacts.yaml
+++ b/.github/workflows/build-squidnat-artefacts.yaml
@@ -65,7 +65,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true

--- a/.github/workflows/deploy-backend.yaml
+++ b/.github/workflows/deploy-backend.yaml
@@ -70,7 +70,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true
@@ -164,7 +164,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true

--- a/.github/workflows/manage-nonprod-rds-clusters.yaml
+++ b/.github/workflows/manage-nonprod-rds-clusters.yaml
@@ -49,7 +49,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             des-globals/env

--- a/.github/workflows/release-manifest.yaml
+++ b/.github/workflows/release-manifest.yaml
@@ -49,7 +49,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true
@@ -105,7 +105,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true
@@ -143,7 +143,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true

--- a/.github/workflows/run-mobile-app-automation.yaml
+++ b/.github/workflows/run-mobile-app-automation.yaml
@@ -52,7 +52,7 @@ jobs:
           aws-region: ${{ secrets.DVSA_AWS_REGION }}
 
       - name: 🤫 Get Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: des-globals/env
           parse-json-secrets: true


### PR DESCRIPTION
## Description

bump all aws-secretsmanager-get-secrets action versions as part of MES-9886

Related issue: [MES-9886](https://dvsa.atlassian.net/browse/MES-9886)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
