### PR TITLE
MES-9886: amend s3 upload step to run if build required

### DIFF
--- a/.github/workflows/build-squidnat-artefacts.yaml
+++ b/.github/workflows/build-squidnat-artefacts.yaml
@@ -121,6 +121,7 @@ jobs:
           echo "file-name=${file_name}" >> $GITHUB_OUTPUT
 
       - name: ☁️ Upload to S3
+        if: steps.artefact-check.outputs.build-required == 'true'
         run: |
           echo "## ☁️ S3 Upload:" >> $GITHUB_STEP_SUMMARY
           s3_upload_path="mes/configs/squidnat"


### PR DESCRIPTION
## Description

amend s3 upload step to run if build required

Related issue: [MES-9886](https://dvsa.atlassian.net/browse/MES-9886)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
