### PR TITLE
MES-9894: remove aws-account input for manage-gha-tf-runner action

### DIFF
--- a/.github/workflows/terraform-deploy-personal.yaml
+++ b/.github/workflows/terraform-deploy-personal.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: dvsa/des-workflow-actions/.github/workflows/manage-gha-tf-runner.yaml@main
     with:
       action: start
-      aws-account: ${{ inputs.aws-account }}
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_NONPROD_ACCOUNT_ID }}
       DVSA_AWS_REGION: ${{ secrets.DVSA_AWS_REGION }}
@@ -303,7 +302,6 @@ jobs:
     uses: dvsa/des-workflow-actions/.github/workflows/manage-gha-tf-runner.yaml@main
     with:
       action: stop
-      aws-account: ${{ inputs.aws-account }}
       runner-label: ${{ needs.start-ec2-runner.outputs.runner-label }}
       ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}
     secrets:

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -61,7 +61,6 @@ jobs:
     uses: dvsa/des-workflow-actions/.github/workflows/manage-gha-tf-runner.yaml@main
     with:
       action: start
-      aws-account: ${{ inputs.aws-account }}
     secrets:
       AWS_ACCOUNT_ID: ${{ inputs.aws-account == 'prod' && secrets.AWS_PROD_ACCOUNT_ID || secrets.AWS_NONPROD_ACCOUNT_ID }}
       DVSA_AWS_REGION: ${{ secrets.DVSA_AWS_REGION }}
@@ -270,7 +269,6 @@ jobs:
     uses: dvsa/des-workflow-actions/.github/workflows/manage-gha-tf-runner.yaml@main
     with:
       action: stop
-      aws-account: ${{ inputs.aws-account }}
       runner-label: ${{ needs.start-ec2-runner.outputs.runner-label }}
       ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}
     secrets:


### PR DESCRIPTION
## Description

remove aws-account input for manage-gha-tf-runner action

Related issue: [MES-9894](https://dvsa.atlassian.net/browse/MES-9894)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
