### PR TITLE
MES-9902: add X64 label as runner for sonar-scan job in deploy-backend.yaml

### DIFF
--- a/.github/workflows/deploy-backend.yaml
+++ b/.github/workflows/deploy-backend.yaml
@@ -137,7 +137,7 @@ jobs:
   sonar-scan:
     needs: build
     if: ${{ !startsWith(inputs.branch, 'release-') }}
-    runs-on: mito-2
+    runs-on: X64
     outputs:
       job-context: ${{ steps.set-outputs.outputs.job-context }}
       steps-context: ${{ steps.set-outputs.outputs.steps-context }}


### PR DESCRIPTION
## Description

add X64 label as runner for sonar-scan job in deploy-backend.yaml

Related issue: [MES-9902](https://dvsa.atlassian.net/browse/MES-9902)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
