### PR TITLE
MES-9900: remove pre-runner-script as new gha runner has been generated

### DIFF
--- a/.github/workflows/build-ami.yaml
+++ b/.github/workflows/build-ami.yaml
@@ -37,9 +37,6 @@ jobs:
     uses: dvsa/des-workflow-actions/.github/workflows/manage-gha-tf-runner.yaml@main
     with:
       action: start
-      pre-runner-script: |
-        sudo dnf update -y
-        sudo dnf install libicu aws-cli mariadb105 git -y
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       DVSA_AWS_REGION: ${{ secrets.DVSA_AWS_REGION }}


### PR DESCRIPTION
## Description

remove pre-runner-script as new gha runner has been generated

Related issue: [MES-9900](https://dvsa.atlassian.net/browse/MES-9900)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
