### PR TITLE
MES-10074: remove setup python step as it's already installed on al2023

### DIFF
--- a/.github/workflows/terraform-deploy-personal.yaml
+++ b/.github/workflows/terraform-deploy-personal.yaml
@@ -272,13 +272,8 @@ jobs:
           ref: ${{ inputs.dynamodb-test-data-branch }}
           token: ${{ secrets.GH_TOKEN_TEMP }}
 
-      - name: ⚙️ Setup Python 3.x
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: ➕ Install Boto3
-        run: pip install boto3
+      - name: ➕ Install Pip
+        run: sudo dnf install python3-pip -y
 
       - name: ➕ Install Requirements
         run: python -m pip install -r requirements.txt --user


### PR DESCRIPTION
## Description

remove setup python step as it's already installed on al2023

Related issue: [MES-10074](https://dvsa.atlassian.net/browse/MES-10074)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
