### PR TITLE
MES-10102: correct previous tag check to look at tags rather than releases

### DIFF
--- a/.github/actions/git-functions/create-releases/action.yaml
+++ b/.github/actions/git-functions/create-releases/action.yaml
@@ -64,7 +64,7 @@ runs:
             previous_release_tag=$(echo "$component_tags" | tail -n 1)
 
             # Fall back to empty string for previous tag if no tags exists to support new repositories being added to repositories.json
-            previous_tag_check=$(gh api /repos/dvsa/$repo/releases | jq -r ".[] | select(.tag_name | test(\"$previous_release_tag\")) | .tag_name")          
+            previous_tag_check=$(gh api /repos/dvsa/$repo/git/matching-refs/tags/$previous_release_tag | jq -r ".[].ref")          
             [[ -z "$previous_tag_check" ]] && previous_release_tag=""
         
             create_release $repo "$previous_release_tag" $release_tag


### PR DESCRIPTION
## Description

correct previous tag check to look at tags rather than releases

Related issue: [MES-10102](https://dvsa.atlassian.net/browse/MES-10102)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
