### PR TITLE
MES-10436: fix output for pre_creation_checks job in release-manifest-des.yaml

### DIFF
--- a/.github/workflows/release-manifest-des.yaml
+++ b/.github/workflows/release-manifest-des.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   pre_creation_checks:
     outputs:
-      service_name: ${{ steps.get_service.outputs.service_name }}
+      service_name: ${{ steps.set_outputs.outputs.service_name }}
       short_sha: ${{ steps.set_outputs.outputs.short_sha }}
       release_build_required: ${{ steps.s3_files.outputs.release_build_required }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

fix output for pre_creation_checks job in release-manifest-des.yaml

Related issue: [MES-10436](https://dvsa.atlassian.net/browse/MES-10436)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[MES-10436]: https://dvsa.atlassian.net/browse/MES-10436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ