### PR TITLE
MES-10448: add step to delete release manifests when undoing a release

### DIFF
--- a/.github/actions/git-functions/delete-branches/action.yaml
+++ b/.github/actions/git-functions/delete-branches/action.yaml
@@ -34,7 +34,7 @@ runs:
 
         # Main Logic
         gh auth setup-git
-        echo "## ${{ inputs.action }} Branch Summary" >> $GITHUB_STEP_SUMMARY
+        echo "## Delete Branch Summary" >> $GITHUB_STEP_SUMMARY
 
         for release_component in ${{ inputs.release-type }}; do
           first_component_repo_name=$(jq -rc ".$release_component[0].repoName" ${{ inputs.repos-json-filename }})

--- a/.github/workflows/undo-release-cut.yaml
+++ b/.github/workflows/undo-release-cut.yaml
@@ -93,7 +93,7 @@ jobs:
           release-type: ${{ steps.get_repositories.outputs.release_type }}
 
       - name: 🗑️ Delete Release Manifests
-        if: inputs.delete-release-tag == 'true'
+        if: inputs.delete-release-tag == 'true' && contains(fromJSON('["backend"]'), inputs.release-type)
         run: | 
           aws s3api list-objects-v2 \
           --bucket ${{ env.DES_GLOBALS_ENV_ARTEFACT_S3 }} \
@@ -109,9 +109,10 @@ jobs:
   
           expected_count=$(jq '.Objects | length' delete.json)
           deleted_count=$(jq '.Deleted | length' <<< "$delete_output")
-  
+          echo "## Delete Release Manifest" >> $GITHUB_STEP_SUMMARY
+          
           if [[ "$expected_count" -eq "$deleted_count" ]]; then
-            echo "✅ All $expected_count objects successfully deleted."
+            echo "✅ All $expected_count release manifests successfully deleted." >> $GITHUB_STEP_SUMMARY
           else
-            echo "❌ Only $deleted_count of $expected_count objects deleted."
+            echo "❌ Only $deleted_count of $expected_count release manifests deleted." >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Description

add step to delete release manifests when undoing a release

Related issue: [MES-10448](https://dvsa.atlassian.net/browse/MES-10448)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[MES-10448]: https://dvsa.atlassian.net/browse/MES-10448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ