### PR TITLE
MES-10525: fix job output usage in generate uat release note step

### DIFF
--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -106,9 +106,9 @@ jobs:
         uses: dvsa/des-workflow-actions/.github/actions/confluence/generate-uat-release-note@main
         with:
           release-tag: ${{ steps.create-release-tag.outputs.frontend-release-tag }}
-          release-type: ${{ jobs.release-cut.outputs.release-type }}
-          frontend-release-tag: ${{ jobs.release-cut.outputs.frontend-release-tag }}
-          backend-release-tag: ${{ jobs.release-cut.outputs.backend-release-tag }}
+          release-type: ${{ needs.release-cut.outputs.release-type }}
+          frontend-release-tag: ${{ needs.release-cut.outputs.frontend-release-tag }}
+          backend-release-tag: ${{ needs.release-cut.outputs.backend-release-tag }}
           parent-page-id: ${{ steps.parent-page.outputs.parent-page-id }}
           confluence-username: ${{ secrets.CONFLUENCE_USER }}
           confluence-api-token: ${{ secrets.CONFLUENCE_TOKEN }}


### PR DESCRIPTION
## Description

fix job output usage in generate uat release note step

Related issue: [MES-10525](https://dvsa.atlassian.net/browse/MES-10525)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
