### PR TITLE
MES-10529: undo release wf update

### DIFF
--- a/.github/workflows/undo-release-cut.yaml
+++ b/.github/workflows/undo-release-cut.yaml
@@ -93,7 +93,7 @@ jobs:
           release-type: ${{ steps.get_repositories.outputs.release_type }}
 
       - name: 🗑️ Delete Release Files
-        if: inputs.delete-release-tag == 'true' && contains(fromJSON('["backend"]'), inputs.release-type)
+        if: inputs.delete-release-tag == 'true' && contains(fromJSON('["full", "backend"]'), inputs.release-type)
         run: |
           for prefix in mes/gha/manifests/releases/ mes/gha/releases/; do
             [[ $prefix == mes/gha/manifests/releases/ ]] && file_type="manifests" || file_type="tfvars"
@@ -101,8 +101,13 @@ jobs:
             aws s3api list-objects-v2 \
             --bucket ${{ env.DES_GLOBALS_ENV_ARTEFACT_S3 }} \
             --prefix $prefix \
-            --query 'Contents[?contains(Key, `${{ inputs.tag-to-delete }}`)].Key' \
+            --query "Contents[?contains(Key, '${{ inputs.tag-to-delete }}')].Key" \
             > files_to_delete.json
+          
+            if jq -e 'length == 0' files_to_delete.json > /dev/null; then
+              echo "❌ No release $file_type found for deletion."
+              continue
+            fi
             
             jq '{Objects: map({Key: .}), Quiet: false}' files_to_delete.json > delete.json
             


### PR DESCRIPTION
## Description

add check to undo-release-cut wf to determine if release files exists prior to deleting

Related issue: [MES-10529](https://dvsa.atlassian.net/browse/MES-10529)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[MES-10529]: https://dvsa.atlassian.net/browse/MES-10529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ