### PR TITLE
MES-10472: fix input for generate-uat-release-note job

### DIFF
--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -99,14 +99,14 @@ jobs:
         id: parent-page
         uses: dvsa/des-workflow-actions/.github/actions/confluence/check_uat_release_parent_pages@main
         with:
-          release-tag: ${{ steps.create-release-tag.outputs.frontend-release-tag }}
+          release-tag: ${{ needs.release-cut.outputs.frontend-release-tag }}
           confluence-user: ${{ secrets.CONFLUENCE_USER }}
           confluence-token: ${{ secrets.CONFLUENCE_TOKEN }}
 
       - name: 📝 Generate UAT Release Note
         uses: dvsa/des-workflow-actions/.github/actions/confluence/generate-uat-release-note@main
         with:
-          release-tag: ${{ steps.create-release-tag.outputs.frontend-release-tag }}
+          release-tag: ${{ needs.release-cut.outputs.frontend-release-tag }}
           release-type: ${{ needs.release-cut.outputs.release-type }}
           frontend-release-tag: ${{ needs.release-cut.outputs.frontend-release-tag }}
           backend-release-tag: ${{ needs.release-cut.outputs.backend-release-tag }}


### PR DESCRIPTION
## Description

fix input for generate-uat-release-note job

Related issue: [MES-10472](https://dvsa.atlassian.net/browse/MES-10472)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[MES-10472]: https://dvsa.atlassian.net/browse/MES-10472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ