### PR TITLE
MES-11190: UAT release note generation fix

### DIFF
--- a/.github/actions/confluence/generate-uat-release-note/uat-release-note-template.txt
+++ b/.github/actions/confluence/generate-uat-release-note/uat-release-note-template.txt
@@ -3,7 +3,7 @@
   <li><a href='#Scope'>Scope</a></li>
   <li><a href='#Implementation-Window'>Implementation Window</a></li>
   <li><a href='#JIRA-Issues-in-Release'>JIRA Issues in Release</a></li>
-  <li><a href='#Application-and-Component-Versions'>Application & Component Versions</a></li>
+  <li><a href='#Application-and-Component-Versions'>Application &amp; Component Versions</a></li>
   <li><a href='#Release-Steps'>Release Steps</a><ul>$RELEASE_STEPS_LIST</ul>
   </li>
 </ol>
@@ -25,7 +25,7 @@
 <ac:structured-macro ac:name='jira'>
   <ac:parameter ac:name="jqlQuery">project = MES AND fixVersion in ("$BRANCH_VERSION", "$VERSION")</ac:parameter>
 </ac:structured-macro>
-<h2 id='Application-and-Component-Versions'>Application & Component Versions</h2>
+<h2 id='Application-and-Component-Versions'>Application &amp; Component Versions</h2>
 <p>$GIT_RELEASE_TAG_SUMMARY</p>
 <table>
   <thead>


### PR DESCRIPTION
## Description

Replace '&' with '\&amp;' to fix confluence unsupported extensions error.

[4.32.1.0 release note](https://dvsa.atlassian.net/wiki/spaces/MES/pages/1226539421/DES+Release+Note+-+Release-4.32.1.0+Backend+Only) has been generated locally by applying the fix in this PR. 

Related issue: [MES-11190](https://dvsa.atlassian.net/browse/MES-11190)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[MES-11190]: https://dvsa.atlassian.net/browse/MES-11190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ