### PR TITLE
MES-11192: UAT release note generation update

### DIFF
--- a/.github/actions/confluence/generate-uat-release-note/action.yaml
+++ b/.github/actions/confluence/generate-uat-release-note/action.yaml
@@ -60,9 +60,29 @@ runs:
         GIT_RELEASE_TAG_SUMMARY=""
         GIT_HASH_TABLE=""
         
+        # Get the minimum app version from Terraform using the release tag
+        get_minimum_app_version() {
+          local tag=$1
+        
+          MINIMUM_APP_VERSION=$(
+            gh api -H "Accept: application/vnd.github.raw+tf" -F ref=$tag \
+            -X GET /repos/dvsa/des-terraform/contents/components/api/variables.tf \
+            | grep -A 3 'minimum_app_version' \
+            | awk -F '=' '{print $2}' \
+            | tail -n 1 \
+            | tr -d ' "'
+          )
+        }
+        
         # Set variables for full and frontend releases
         if [ "${{ inputs.release-type }}" == "frontend backend" ] || [ "${{ inputs.release-type }}" == "frontend" ]; then
-          [ "${{ inputs.release-type }}" == "frontend" ] && RELEASE_TYPE="(FE Only)"
+          if [ "${{ inputs.release-type }}" == "frontend" ]; then
+            RELEASE_TYPE="(FE Only)"
+            latest_backend_release=$(gh api /repos/dvsa/des-terraform/releases/latest | jq '.tag_name' | tr -d '"')
+        
+            get_minimum_app_version $latest_backend_release
+          fi
+        
           RELEASE_STEPS_LIST+="<li><a href='#Mobile-App'>Mobile App</a></li>"
           IMPLEMENTATION_WINDOW_ROWS+="<tr><td>Mobile App</td><td><code>$(date '+%d-%h-%Y' | sed 's/-/ /g')</code></td></tr>"
           RELEASE_STEPS_SECTION+="<h3 id='Mobile-App'>Mobile App</h3><p>For UAT builds, download the IPA from the 'GHA - Build Mobile App Artefact' Teams Channel and upload to Intune</p>"
@@ -71,6 +91,9 @@ runs:
         # Set variables for full and backend releases
         if [ "${{ inputs.release-type }}" == "frontend backend" ] || [ "${{ inputs.release-type }}" == "backend" ]; then
           [ "${{ inputs.release-type }}" == "backend" ] && RELEASE_TYPE="(BE Only)"
+        
+          get_minimum_app_version $BACKEND_RELEASE_TAG
+        
           RELEASE_STEPS_LIST+="<li><a href='#Backend'>Backend</a></li>"
           IMPLEMENTATION_WINDOW_ROWS+="<tr><td>Backend</td><td><code>$(date '+%d-%h-%Y' | sed 's/-/ /g')</code></td></tr>"
           RELEASE_STEPS_SECTION+="<h3 id='Backend'>Backend</h3>\
@@ -94,6 +117,11 @@ runs:
               <tr><td>Additional Terraform Arguments</td><td>N/A</td></tr>\
             </tbody>\
           </table>"
+        fi
+        
+        # Fallback value for MINIMUM_APP_VERSION
+        if [[ -z $MINIMUM_APP_VERSION ]]; then
+          MINIMUM_APP_VERSION="TBC"
         fi
         
         # Generate the git commit hash table
@@ -121,6 +149,7 @@ runs:
             -e "s/\$VERSION/${VERSION}/g" \
             -e "s/\$BRANCH_VERSION/${BRANCH_VERSION}/g" \
             -e "s/\$RELEASE_STEPS_LIST/${RELEASE_STEPS_LIST//\//\\/}/" \
+            -e "s/\$MINIMUM_APP_VERSION/${MINIMUM_APP_VERSION//\//\\/}/" \
             -e "s/\$IMPLEMENTATION_WINDOW_ROWS/${IMPLEMENTATION_WINDOW_ROWS//\//\\/}/" \
             -e "s/\$RELEASE_STEPS_SECTION/${RELEASE_STEPS_SECTION//\//\\/}/" \
             -e "s/\$GIT_RELEASE_TAG_SUMMARY/${GIT_RELEASE_TAG_SUMMARY//\//\\/}/" \

--- a/.github/actions/confluence/generate-uat-release-note/uat-release-note-template.txt
+++ b/.github/actions/confluence/generate-uat-release-note/uat-release-note-template.txt
@@ -1,6 +1,7 @@
 <h2>Table of Contents</h2>
 <ol>
   <li><a href='#Scope'>Scope</a></li>
+  <li><a href='#Config'>Config</a></li>
   <li><a href='#Implementation-Window'>Implementation Window</a></li>
   <li><a href='#JIRA-Issues-in-Release'>JIRA Issues in Release</a></li>
   <li><a href='#Application-and-Component-Versions'>Application &amp; Component Versions</a></li>
@@ -8,7 +9,20 @@
   </li>
 </ol>
 <h2 id='Scope'>Scope</h2>
-<p>&lt; INSERT ADDITIONAL INFORMATION &gt;</p>
+<p><span style="color: rgb(255,0,0);">&lt; INSERT ADDITIONAL INFORMATION &gt;</span></p>
+<h2 id='Config'>Config</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Minimum App Version</td><td>$MINIMUM_APP_VERSION</td></tr>
+    <tr><td>Mobile App Config xml file</td><td>TBC</td></tr>
+  </tbody>
+</table>
 <h2 id='Implementation-Window'>Implementation Window</h2>
 <table>
   <thead>

--- a/.github/actions/confluence/generate-uat-release-note/uat-release-note-template.txt
+++ b/.github/actions/confluence/generate-uat-release-note/uat-release-note-template.txt
@@ -11,6 +11,12 @@
 <h2 id='Scope'>Scope</h2>
 <p><span style="color: rgb(255,0,0);">&lt; INSERT ADDITIONAL INFORMATION &gt;</span></p>
 <h2 id='Config'>Config</h2>
+<ac:structured-macro ac:name="note">
+  <ac:rich-text-body>
+    <p>For frontend-only releases, the minimum app version is retrieved from the des-terraform repository using the latest backend release tag.</p>
+    <p>As the UAT and production minimum app version may not be aligned, always verify that the generated value matches the version currently deployed in production.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
## Description

Update the UAT release note generation action to automatically retrieve the minimum app version from where it is set in the Terraform code. For full and backend releases, the minimum app version will be retrieved utilising the release tag. For frontend only releases, the minimum app version will be retrieved by getting the release tag of the latest backend release.

I have tested this locally posting UAT release notes to [this](https://dvsa.atlassian.net/wiki/spaces/MES/pages/1205176833/V4.32.0) section in Confluence. 

Related issue: [MES-11192](https://dvsa.atlassian.net/browse/MES-11192)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[MES-11192]: https://dvsa.atlassian.net/browse/MES-11192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ