### PR TITLE
Fix (mes 11271): Resolving compatability issues with Terraform 1.0.0

### DIFF
--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -124,8 +124,8 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
-          terraform init components/${{ inputs.tf-component }}
-          terraform show -no-color components/${{ inputs.tf-component }}/tfplan > ${{ github.workspace }}/$filename
+          terraform -chdir=components/${{ inputs.tf-component }} init
+          terraform -chdir=components/${{ inputs.tf-component }} show -no-color tfplan > ${{ github.workspace }}/$filename
 
       - name: ☁️ Upload Plan
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -129,8 +129,8 @@ jobs:
           terraform {
           backend "s3" {
           region = "${{ secrets.DVSA_AWS_REGION }}"
-          bucket = "dvsa.mes.tf-${{ secrets.AWS_NONPROD_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
-          key    = "mes/${{ secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
+          bucket = "dvsa.mes.tf-${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
+          key    = "mes/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
           }
           }
           EOF

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -111,10 +111,7 @@ jobs:
           --region ${{ secrets.DVSA_AWS_REGION }} \
           -- ${{ steps.get-tfvars.outputs.tfvars }} \
           ${{ inputs.tf-args }} \
-          ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }} \
-          cd components/${{ inputs.tf-component }}
-          terraform show -json tfplan >/tmp/plan.json
-          echo "terraform show succeeded"
+          ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }} 
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -112,6 +112,8 @@ jobs:
           -- ${{ steps.get-tfvars.outputs.tfvars }} \
           ${{ inputs.tf-args }} \
           ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
+          cd components/${{ inputs.tf-component }}
+          terraform version
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -126,7 +126,7 @@ jobs:
           
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
-          terraform show -no-color tfplan >  ${{ github.workspace }}/$filename
+          terraform show -no-color -json tfplan >  ${{ github.workspace }}/$filename
           cd ../..
 
       - name: ☁️ Upload Plan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -128,9 +128,9 @@ jobs:
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
           cat .terraform/terraform.tfstate
-          ls -la 
-          ls -la ../..
-          terraform show -no-color -json tfplan >  ${{ github.workspace }}/$filename
+          ls -lh tfplan
+          cat tfplan
+          terraform show tfplan
           cd ../..
 
       - name: ☁️ Upload Plan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -114,8 +114,9 @@ jobs:
           ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
           cd components/${{ inputs.tf-component }}
           terraform version
+          echo "providers including aws provider version is"
           terraform providers
-          ls -lh tfplan
+          ls -lh tfplan  
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -126,6 +126,7 @@ jobs:
           
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
+          cp ../../tfplan tfplan
           terraform show -no-color -json tfplan >  ${{ github.workspace }}/$filename
           cd ../..
 

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -130,16 +130,25 @@ jobs:
           
           cat components/${{ inputs.tf-component }}/.terraform/terraform.tfstate
           cd components/${{ inputs.tf-component }}
-          terraform init -reconfigure \
-          -backend-config="bucket=dvsa.mes.tf-${{ inputs.aws-account }}-${{ secrets.DVSA_AWS_REGION }}" \
-          -backend-config="key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate" \
-          -backend-config="region=${{ secrets.DVSA_AWS_REGION }}"
+          cat > backend_terraformscaffold.tf <<'EOF'
+          terraform {
+          backend "s3" {
+          region = "${{ secrets.DVSA_AWS_REGION }}"
+          bucket = "dvsa.mes.tf-${{ secrets.AWS_NONPROD_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
+          key    = "mes/${{ secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
+          }
+          }
+          EOF
+          echo "=== backend_terraformscaffold.tf ==="
+          cat backend_terraformscaffold.tf
+          terraform init -reconfigure 
           echo "key=mes/${{ secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
-          echo "bucket=dvsa.mes.tf-${{ inputs.aws-account }}-${{ secrets.DVSA_AWS_REGION }}"
+          echo "bucket=dvsa.mes.tf-${{ secrets.AWS_NONPROD_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
           cat .terraform-version
           terraform version
           cat .terraform/terraform.tfstate
-          echo "terraform providers"
+          echo "=== terraform providers ==="
+          terraform providers
           ls -lh tfplan
           terraform show tfplan
           cd ../..

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -129,7 +129,6 @@ jobs:
           terraform init -reconfigure
           cat .terraform/terraform.tfstate
           ls -lh tfplan
-          cat tfplan
           terraform show tfplan
           cd ../..
 

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -134,6 +134,7 @@ jobs:
           -backend-config="bucket=dvsa.mes.tf-${{ inputs.aws-account }}-${{ secrets.DVSA_AWS_REGION }}" \
           -backend-config="key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-environment }}.tfstate" \
           -backend-config="region=${{ secrets.DVSA_AWS_REGION }}"
+          echo "key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-environment }}.tfstate"
           cat .terraform-version
           terraform version
           echo "terraform providers"

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -126,7 +126,8 @@ jobs:
           
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
-          cp ../../tfplan tfplan
+          ls -la 
+          ls -la ../..
           terraform show -no-color -json tfplan >  ${{ github.workspace }}/$filename
           cd ../..
 

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -129,8 +129,8 @@ jobs:
           terraform {
           backend "s3" {
           region = "${{ secrets.DVSA_AWS_REGION }}"
-          bucket = "dvsa.mes.tf-${{ inputs.aws-account == 'prod' && secrets.DES_AWS_ROLE_PROD || secrets.DES_AWS_ROLE_NONPROD }}-${{ secrets.DVSA_AWS_REGION }}"
-          key    = "mes/${{ inputs.aws-account == 'prod' && secrets.DES_AWS_ROLE_PROD || secrets.DES_AWS_ROLE_NONPROD }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
+          bucket = "dvsa.mes.tf-${{ inputs.aws-account == 'prod' && secrets.AWS_PROD_ACCOUNT_ID || secrets.AWS_NONPROD_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
+          key    = "mes/${{ inputs.aws-account == 'prod' && secrets.AWS_PROD_ACCOUNT_ID || secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
           }
           }
           EOF

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -127,7 +127,6 @@ jobs:
           cat components/${{ inputs.tf-component }}/.terraform/terraform.tfstate
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
-          cat .terraform/terraform.tfstate
           ls -lh tfplan
           terraform show tfplan
           cd ../..

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -129,8 +129,8 @@ jobs:
           terraform {
           backend "s3" {
           region = "${{ secrets.DVSA_AWS_REGION }}"
-          bucket = "dvsa.mes.tf-${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
-          key    = "mes/${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
+          bucket = "dvsa.mes.tf-${{ inputs.aws-account == 'prod' && secrets.DES_AWS_ROLE_PROD || secrets.DES_AWS_ROLE_NONPROD }}-${{ secrets.DVSA_AWS_REGION }}"
+          key    = "mes/${{ inputs.aws-account == 'prod' && secrets.DES_AWS_ROLE_PROD || secrets.DES_AWS_ROLE_NONPROD }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
           }
           }
           EOF

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -150,7 +150,7 @@ jobs:
           echo "=== terraform providers ==="
           terraform providers
           ls -lh tfplan
-          terraform show tfplan
+          terraform show tfplan > ${{ github.workspace }}/$filename
           cd ../..
 
       - name: ☁️ Upload Plan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -124,7 +124,7 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
-          terraform -chdir=components/${{ inputs.tf-component }} init
+#          terraform -chdir=components/${{ inputs.tf-component }} init
           terraform -chdir=components/${{ inputs.tf-component }} show -no-color tfplan > ${{ github.workspace }}/$filename
 
       - name: ☁️ Upload Plan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -111,7 +111,10 @@ jobs:
           --region ${{ secrets.DVSA_AWS_REGION }} \
           -- ${{ steps.get-tfvars.outputs.tfvars }} \
           ${{ inputs.tf-args }} \
-          ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
+          ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }} \
+          cd components/${{ inputs.tf-component }}
+          terraform show -json tfplan >/tmp/plan.json
+          echo "terraform show succeeded"
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -114,6 +114,8 @@ jobs:
           ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
           cd components/${{ inputs.tf-component }}
           terraform version
+          terraform providers
+          ls -lh tfplan
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}
@@ -131,6 +133,8 @@ jobs:
           terraform init -reconfigure
           cat .terraform-version
           terraform version
+          terraform providers
+          ls -lh tfplan
           ls -la
           terraform show tfplan
           cd ../..

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -132,9 +132,9 @@ jobs:
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure \
           -backend-config="bucket=dvsa.mes.tf-${{ inputs.aws-account }}-${{ secrets.DVSA_AWS_REGION }}" \
-          -backend-config="key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-environment }}.tfstate" \
+          -backend-config="key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate" \
           -backend-config="region=${{ secrets.DVSA_AWS_REGION }}"
-          echo "key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-environment }}.tfstate"
+          echo "key=mes/${{ secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
           cat .terraform-version
           terraform version
           echo "terraform providers"

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -111,7 +111,7 @@ jobs:
           --region ${{ secrets.DVSA_AWS_REGION }} \
           -- ${{ steps.get-tfvars.outputs.tfvars }} \
           ${{ inputs.tf-args }} \
-          ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }} 
+          ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}
@@ -124,13 +124,10 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
-          terraform -chdir=components/${{ inputs.tf-component }} init -reconfigure
           cd components/${{ inputs.tf-component }}
-          terraform version
-          ls -la
-          ls -la .terraform
-  
-          terraform show -no-color tfplan > ${{ github.workspace }}/$filename
+          terraform init -reconfigure
+          terraform show -no-color tfplan >  ${{ github.workspace }}/$filename
+          cd ../..
 
       - name: ☁️ Upload Plan
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -124,6 +124,7 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
+          terraform -chdir=components/${{ inputs.tf-component }} init -reconfigure
           terraform -chdir=components/${{ inputs.tf-component }} show -no-color tfplan > ${{ github.workspace }}/$filename
 
       - name: ☁️ Upload Plan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -128,6 +128,7 @@ jobs:
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
           cat .terraform-version
+          terraform version
           ls -la
           terraform show tfplan
           cd ../..

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -114,8 +114,7 @@ jobs:
           ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
           cd components/${{ inputs.tf-component }}
           terraform version
-          echo "providers including aws provider version is"
-          terraform providers
+          echo "providers including aws provider version is terraform providers"
           ls -lh tfplan  
 
       - name: 🧐 Terraform Show
@@ -131,10 +130,13 @@ jobs:
           
           cat components/${{ inputs.tf-component }}/.terraform/terraform.tfstate
           cd components/${{ inputs.tf-component }}
-          terraform init -reconfigure
+          terraform init -reconfigure \
+          -backend-config="bucket=dvsa.mes.tf-${{ inputs.aws-account }}-${{ secrets.DVSA_AWS_REGION }}" \
+          -backend-config="key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-environment }}.tfstate" \
+          -backend-config="region=${{ secrets.DVSA_AWS_REGION }}"
           cat .terraform-version
           terraform version
-          terraform providers
+          ehco "terraform providers"
           ls -lh tfplan
           ls -la
           terraform show tfplan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -127,7 +127,8 @@ jobs:
           cat components/${{ inputs.tf-component }}/.terraform/terraform.tfstate
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
-          ls -lh tfplan
+          cat .terraform-version
+          ls -la
           terraform show tfplan
           cd ../..
 

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -113,9 +113,6 @@ jobs:
           ${{ inputs.tf-args }} \
           ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
           cd components/${{ inputs.tf-component }}
-          terraform version
-          echo "providers including aws provider version is terraform providers"
-          ls -lh tfplan  
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}
@@ -128,7 +125,6 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
-          cat components/${{ inputs.tf-component }}/.terraform/terraform.tfstate
           cd components/${{ inputs.tf-component }}
           cat > backend_terraformscaffold.tf <<'EOF'
           terraform {
@@ -139,17 +135,7 @@ jobs:
           }
           }
           EOF
-          echo "=== backend_terraformscaffold.tf ==="
-          cat backend_terraformscaffold.tf
           terraform init -reconfigure 
-          echo "key=mes/${{ secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
-          echo "bucket=dvsa.mes.tf-${{ secrets.AWS_NONPROD_ACCOUNT_ID }}-${{ secrets.DVSA_AWS_REGION }}"
-          cat .terraform-version
-          terraform version
-          cat .terraform/terraform.tfstate
-          echo "=== terraform providers ==="
-          terraform providers
-          ls -lh tfplan
           terraform show tfplan > ${{ github.workspace }}/$filename
           cd ../..
 

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -125,7 +125,12 @@ jobs:
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
           terraform -chdir=components/${{ inputs.tf-component }} init -reconfigure
-          terraform -chdir=components/${{ inputs.tf-component }} show -no-color tfplan > ${{ github.workspace }}/$filename
+          cd components/${{ inputs.tf-component }}
+          terraform version
+          ls -la
+          ls -la .terraform
+  
+          terraform show -no-color tfplan > ${{ github.workspace }}/$filename
 
       - name: ☁️ Upload Plan
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -112,7 +112,6 @@ jobs:
           -- ${{ steps.get-tfvars.outputs.tfvars }} \
           ${{ inputs.tf-args }} \
           ${{ contains(fromJSON('["plan", "plan-destroy"]'), inputs.tf-action) && '-out=tfplan' || '' }}
-          cd components/${{ inputs.tf-component }}
 
       - name: 🧐 Terraform Show
         if: ${{ inputs.tf-action == 'plan' || inputs.tf-action == 'plan-destroy' }}

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -124,7 +124,6 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
-#          terraform -chdir=components/${{ inputs.tf-component }} init
           terraform -chdir=components/${{ inputs.tf-component }} show -no-color tfplan > ${{ github.workspace }}/$filename
 
       - name: ☁️ Upload Plan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -135,11 +135,12 @@ jobs:
           -backend-config="key=mes/${{ inputs.aws-account }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate" \
           -backend-config="region=${{ secrets.DVSA_AWS_REGION }}"
           echo "key=mes/${{ secrets.AWS_NONPROD_ACCOUNT_ID }}/${{ secrets.DVSA_AWS_REGION }}/${{ inputs.tf-environment }}/${{ inputs.tf-component }}.tfstate"
+          echo "bucket=dvsa.mes.tf-${{ inputs.aws-account }}-${{ secrets.DVSA_AWS_REGION }}"
           cat .terraform-version
           terraform version
+          cat .terraform/terraform.tfstate
           echo "terraform providers"
           ls -lh tfplan
-          ls -la
           terraform show tfplan
           cd ../..
 

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -136,7 +136,7 @@ jobs:
           -backend-config="region=${{ secrets.DVSA_AWS_REGION }}"
           cat .terraform-version
           terraform version
-          ehco "terraform providers"
+          echo "terraform providers"
           ls -lh tfplan
           ls -la
           terraform show tfplan

--- a/.github/workflows/terraform-action.yaml
+++ b/.github/workflows/terraform-action.yaml
@@ -124,8 +124,10 @@ jobs:
           
           echo "FILE_NAME=$filename" >> $GITHUB_ENV
           
+          cat components/${{ inputs.tf-component }}/.terraform/terraform.tfstate
           cd components/${{ inputs.tf-component }}
           terraform init -reconfigure
+          cat .terraform/terraform.tfstate
           ls -la 
           ls -la ../..
           terraform show -no-color -json tfplan >  ${{ github.workspace }}/$filename

--- a/.github/workflows/terraform-deploy-personal.yaml
+++ b/.github/workflows/terraform-deploy-personal.yaml
@@ -165,7 +165,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -185,7 +185,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -205,7 +205,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -225,7 +225,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -146,7 +146,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: [plan, apply]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -164,7 +164,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: [plan, apply]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -184,7 +184,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: [ plan, apply ]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -204,7 +204,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: [plan, apply]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -267,7 +267,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: [plan, apply]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/terraform-full-deploy.yaml
+++ b/.github/workflows/terraform-full-deploy.yaml
@@ -106,7 +106,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -127,7 +127,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -148,7 +148,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: [ "${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}" ]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -169,7 +169,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -190,7 +190,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}
@@ -211,7 +211,7 @@ jobs:
       max-parallel: 1
       matrix:
         tf-action: ["${{ needs.set-tf-args.outputs.tf-plan-action }}", "${{ inputs.tf-action }}"]
-    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@main
+    uses: dvsa/des-workflow-actions/.github/workflows/terraform-action.yaml@fix/mes_11271_passing_a_directory_was_deprecated_for_tf_1_upgrade
     with:
       runner: ${{ needs.start-ec2-runner.outputs.runner-label }}
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
## Description

The current workflow is not compatible with Terraform 1.0.0 due to changes in Terraform's handling of backend configuration and the deprecation of inline state/backend paths.

This MR resolves both these issues, while maintaining backwards compatibility with Terraform 0.14.11
  

Related issue: [MES-11315](https://dvsa.atlassian.net/browse/MES-11315)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working


jobs run to check backwards compatability 
re applying (plan then apply) mgmt with TF 0.14.11 and zero changes 
https://github.com/dvsa/des-devops/actions/runs/32118290473

plan for drs for dev with TF 0.14.11
https://github.com/dvsa/des-devops/actions/runs/32114969535

plan for api for dev with TF 1.0.0 
https://github.com/dvsa/des-devops/actions/runs/32114796814

[MES-11315]: https://dvsa.atlassian.net/browse/MES-11315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ